### PR TITLE
SwiftLint added to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,12 @@ Reading List uses a couple of package managers:
 
 - [Mint](https://github.com/yonaskolb/Mint), to manage Swift command line tool packages
 - [Bundler](https://github.com/bundler/bundler), to manage Ruby tools
+- [SwiftLint](https://github.com/realm/SwiftLint), to enforce Swift style and conventions
 
-Mint can be installed using [Homebrew](https://brew.sh/) (among [other methods](https://github.com/yonaskolb/Mint#installing)); Bundler can be installed with [RubyGems](https://rubygems.org/):
+Mint and SwiftLint can be installed using [Homebrew](https://brew.sh/) (among [other methods](https://github.com/yonaskolb/Mint#installing)); Bundler can be installed with [RubyGems](https://rubygems.org/):
 
     brew install mint
+    brew install swiftlint
     gem install bundler
 
 ### XcodeGen


### PR DESCRIPTION
The required SwitftLint dependency was missing from the README. Without it gave the following error when tried to build the workspace:

```
/Users/username/Library/Developer/Xcode/DerivedData/ReadingList-corlcimrvcpjejahgzkbgriabezz/Build/Intermediates.noindex/ReadingList.build/Debug-iphonesimulator/ReadingList.build/Script-SSBP_5390473549.sh: line 3: /usr/local/bin/swiftlint: No such file or directory
Command PhaseScriptExecution failed with a nonzero exit code
```