### PR TITLE
Better support import of CSV files

### DIFF
--- a/ReadingList/Info.plist
+++ b/ReadingList/Info.plist
@@ -16,7 +16,7 @@
 			<key>CFBundleTypeRole</key>
 			<string>Viewer</string>
 			<key>LSHandlerRank</key>
-			<string>Owner</string>
+			<string>Alternate</string>
 			<key>LSItemContentTypes</key>
 			<array>
 				<string>public.comma-separated-values-text</string>
@@ -101,7 +101,7 @@
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
 	<key>UISupportsDocumentBrowser</key>
-	<true/>
+	<false/>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<true/>
 </dict>

--- a/ReadingList/Info.plist
+++ b/ReadingList/Info.plist
@@ -57,6 +57,8 @@
 	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>LSSupportsOpeningDocumentsInPlace</key>
+	<false/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsLocalNetworking</key>


### PR DESCRIPTION
Change `LSHandlerRank` and `UISupportsDocumentBrowser` properties so that files are not opened by default in the app, and so files from the Files app can be imported successfully.