### PR TITLE
When updating a book's progress, auto-select textfield's contents

### DIFF
--- a/ReadingList/ViewControllers/Edit/EditBookReadState.swift
+++ b/ReadingList/ViewControllers/Edit/EditBookReadState.swift
@@ -122,19 +122,21 @@ final class EditBookReadState: FormViewController {
 
         // If we are editing a book (not adding one), pre-select the current page field
         if self.book.readState == .reading && self.book.changedValues().isEmpty {
-            guard let progressRow = [progressPageKey, progressPercentageKey].map({
-                self.form.rowBy(tag: $0) as! Int32Row
-            }).first(where: { !$0.isHidden }) else {
+            guard
+                let progressRow = [progressPageKey, progressPercentageKey].map({
+                    self.form.rowBy(tag: $0) as! Int32Row
+                }).first(where: { !$0.isHidden }),
+                let textField = progressRow.cell.textField
+            else {
                 assertionFailure("Neither percentage nor page visible")
                 return
             }
-            progressRow.cell.textField.becomeFirstResponder()
-            if let textField = progressRow.cell.textField {
-                textField.selectedTextRange = textField.textRange(
-                    from: textField.beginningOfDocument,
-                    to: textField.endOfDocument
-                )
-            }
+
+            textField.becomeFirstResponder()
+            textField.selectedTextRange = textField.textRange(
+                from: textField.beginningOfDocument,
+                to: textField.endOfDocument
+            )
         }
     }
 

--- a/ReadingList/ViewControllers/Edit/EditBookReadState.swift
+++ b/ReadingList/ViewControllers/Edit/EditBookReadState.swift
@@ -129,6 +129,12 @@ final class EditBookReadState: FormViewController {
                 return
             }
             progressRow.cell.textField.becomeFirstResponder()
+            if let textField = progressRow.cell.textField {
+                textField.selectedTextRange = textField.textRange(
+                    from: textField.beginningOfDocument,
+                    to: textField.endOfDocument
+                )
+            }
         }
     }
 


### PR DESCRIPTION
Hey there! Thanks for making such a fantastic app. It's been on my homescreen for a while, it's a delightful nudge to keep reading.

One small suggestion-nit is that it'd be faster to update the progress for a book if the textfield's contents are selected when the "Update" button is tapped. I'm often reading a book, and want to update the progress from, say, `32%` to `48%`, so it'd be faster if I could just type `48` instead of having to delete the contents and then type `48`.

(I know this is a terribly-small nit! No worries if you don't want to merge it!)

Here's a GIF of it in action:
![select-textfield-contents-on-modal-presentation](https://user-images.githubusercontent.com/868389/87844778-98e38d80-c875-11ea-8e9b-d09fdfd41889.gif)
