### PR TITLE
Don't require cancel-confirmation if no edits were made on a new book

### DIFF
--- a/ReadingList/ViewControllers/Edit/EditBookMetadata.swift
+++ b/ReadingList/ViewControllers/Edit/EditBookMetadata.swift
@@ -338,7 +338,17 @@ final class EditBookMetadata: FormViewController {
     }
 
     @objc func userDidCancel() {
-        guard book.changedValues().isEmpty else {
+        let onlyTrivialChangesOccurred: Bool
+        if self.isAddingNewBook {
+            let trivialChanges = ["addedWhen", "manualBookId"]
+            onlyTrivialChangesOccurred = book.changedValues()
+                .filter { !trivialChanges.contains($0.key) }
+                .isEmpty
+        } else {
+            onlyTrivialChangesOccurred = !book.changedValues().isEmpty
+        }
+
+        guard onlyTrivialChangesOccurred else {
             // Confirm exit dialog
             let confirmExit = UIAlertController(title: "Unsaved changes", message: "Are you sure you want to discard your unsaved changes?", preferredStyle: .actionSheet)
             confirmExit.addAction(UIAlertAction(title: "Discard", style: .destructive) { _ in

--- a/ReadingList/ViewControllers/Edit/EditBookMetadata.swift
+++ b/ReadingList/ViewControllers/Edit/EditBookMetadata.swift
@@ -340,7 +340,10 @@ final class EditBookMetadata: FormViewController {
     @objc func userDidCancel() {
         let noConfirmationNeeded: Bool
         if self.isAddingNewBook {
-            let trivialChanges = ["addedWhen", "manualBookId"]
+            let trivialChanges = [
+                #keyPath(Book.addedWhen),
+                #keyPath(Book.manualBookId),
+            ]
             noConfirmationNeeded = book.changedValues()
                 .filter { !trivialChanges.contains($0.key) }
                 .isEmpty

--- a/ReadingList/ViewControllers/Edit/EditBookMetadata.swift
+++ b/ReadingList/ViewControllers/Edit/EditBookMetadata.swift
@@ -338,17 +338,17 @@ final class EditBookMetadata: FormViewController {
     }
 
     @objc func userDidCancel() {
-        let onlyTrivialChangesOccurred: Bool
+        let noConfirmationNeeded: Bool
         if self.isAddingNewBook {
             let trivialChanges = ["addedWhen", "manualBookId"]
-            onlyTrivialChangesOccurred = book.changedValues()
+            noConfirmationNeeded = book.changedValues()
                 .filter { !trivialChanges.contains($0.key) }
                 .isEmpty
         } else {
-            onlyTrivialChangesOccurred = !book.changedValues().isEmpty
+            noConfirmationNeeded = book.changedValues().isEmpty
         }
 
-        guard onlyTrivialChangesOccurred else {
+        guard noConfirmationNeeded else {
             // Confirm exit dialog
             let confirmExit = UIAlertController(title: "Unsaved changes", message: "Are you sure you want to discard your unsaved changes?", preferredStyle: .actionSheet)
             confirmExit.addAction(UIAlertAction(title: "Discard", style: .destructive) { _ in


### PR DESCRIPTION
In the app today, if you accidentally tap the "Add manual" option when adding a book, then you have to tap "Cancel" and then _confirm cancelling_ to get back out to the main screen.

With this fix, you no longer need to confirm-cancellation of an accidentally-created manual book! See attached videos.

Before this change:
![before-the-fix](https://user-images.githubusercontent.com/868389/87845089-dac20300-c878-11ea-86fe-bbde82bb621f.gif)

After this change:
![after-the-fix](https://user-images.githubusercontent.com/868389/87845097-fdecb280-c878-11ea-8c7c-08f70af0213c.gif)