### PR TITLE
Show the count of items instead of "All" when multi-selecting items

### DIFF
--- a/ReadingList/ViewControllers/BookTable/BookTable.swift
+++ b/ReadingList/ViewControllers/BookTable/BookTable.swift
@@ -348,7 +348,7 @@ final class BookTable: UITableViewController { //swiftlint:disable:this type_bod
         })
 
         if let initialSelectionReadState = selectedReadStates.first, initialSelectionReadState != .finished, selectedReadStates.count == 1 {
-            let title = (initialSelectionReadState == .toRead ? "Start" : "Finish") + (selectedRows.count > 1 ? " All" : "")
+            let title = (initialSelectionReadState == .toRead ? "Start" : "Finish") + (selectedRows.count > 1 ? " \(selectedRows.count)" : "")
             optionsAlert.addAction(UIAlertAction(title: title, style: .default) { _ in
 
                 // We need to manage the sort indices manually, since we will be saving the batch operation at once
@@ -374,7 +374,7 @@ final class BookTable: UITableViewController { //swiftlint:disable:this type_bod
             })
         }
 
-        optionsAlert.addAction(UIAlertAction(title: "Delete\(selectedRows.count > 1 ? " All" : "")", style: .destructive) { _ in
+        optionsAlert.addAction(UIAlertAction(title: "Delete\(selectedRows.count > 1 ? " \(selectedRows.count)" : "")", style: .destructive) { _ in
             let confirm = self.confirmDeleteAlert(indexPaths: selectedRows) { didDelete in
                 // Once the deletion has happened, switch editing mode off. Do this on the next run loop to avoid
                 // messing with the row deletion animations


### PR DESCRIPTION
The other day, I was cleaning up my list of To-Read books, and used the **Edit > Multiselect > Delete** option (this is `editActionButtonPressed` in the source code). 

The UIAlertController's actions had titles that caught me off guard - for a moment, I thought that tapping the Delete (or Start) buttons would delete all the books in my To-Read list (of course, the actual feature is to delete only the selected ones!)

I think there are a bunch of ways to consider for changing the copy - the two that come to mind for me are "Delete 2", or "Delete Selected".

What do you prefer? I think I prefer the count, but could go either way.

<img width="608" alt="Napkin 2 08-24-20, 9 16 11 AM" src="https://user-images.githubusercontent.com/868389/91069610-74a06c80-e5ea-11ea-926f-ba85c820c122.png">